### PR TITLE
IE Portal Position Fix

### DIFF
--- a/src/MentionWrapper.js
+++ b/src/MentionWrapper.js
@@ -67,10 +67,10 @@ class MentionWrapper extends Component {
         this.setState({
           active: 0,
           child,
-          left: window.scrollX + coords.left + left + this.ref.scrollLeft,
+          left: window.pageXOffset + coords.left + left + this.ref.scrollLeft,
           triggerIdx,
           top:
-            window.scrollY +
+            window.pageYOffset +
             coords.top +
             top +
             coords.height -


### PR DESCRIPTION
I was debugging an issue with the portal not displaying in the correct location in IE11 and found that window.scrollX and window.scrollY (used in https://github.com/mattkrick/react-githubish-mentions/blob/master/src/MentionWrapper.js#L70) were undefined.

Per https://developer.mozilla.org/en-US/docs/Web/API/Window/scrollX [window.pageXOffset](https://developer.mozilla.org/en-US/docs/Web/API/Window/pageXOffset)/[window.pageYOffset](https://developer.mozilla.org/en-US/docs/Web/API/Window/pageYOffset) are a supported cross browser alias for all browsers (and ie9+)