### PR TITLE
Fix positioning after hover over with mouse

### DIFF
--- a/src/MentionMenu.js
+++ b/src/MentionMenu.js
@@ -10,8 +10,20 @@ class MentionMenu extends React.Component {
     };
   }
   componentWillReceiveProps(nextProps) {
-    if (nextProps.left != this.state.left || nextProps.top != this.state.top) {
-      this.setState({ left: nextProps.left, right: nextProps.right });
+    let left = nextProps.left;
+    let top = nextProps.top;
+
+    //prevent menu from going off the right of the screen
+    if (this.node && left + this.node.offsetWidth > window.innerWidth) {
+      left = window.innerWidth - (this.node.offsetWidth + 10);
+    }
+    //prevent menu from going off bottom of screen
+    if (this.node && top + this.node.offsetHeight > window.innerHeight) {
+      top = window.innerHeight - (this.node.offsetHeight + 10);
+    }
+
+    if (left != this.state.left || top != this.state.top) {
+      this.setState({ left, right });
     }
   }
   componentDidMount() {

--- a/src/MentionMenu.js
+++ b/src/MentionMenu.js
@@ -23,7 +23,7 @@ class MentionMenu extends React.Component {
     }
 
     if (left != this.state.left || top != this.state.top) {
-      this.setState({ left, right });
+      this.setState({ left, top });
     }
   }
   componentDidMount() {


### PR DESCRIPTION
Fix: When the menu is too far to the right and you hover over with your mouse it renders off the screen again.